### PR TITLE
style: Avoid using keywords `Static` and `eff`

### DIFF
--- a/src/Ast.flix
+++ b/src/Ast.flix
@@ -9,12 +9,12 @@ mod Ast {
     use Namespace.Namespace;
     use Type_.{Int8_, Int16_, Int32_, Int64_, Float32_, Float64_, Bool_, Char_, String_, BigInt_, Unit_, Ref_, Array_, Result_, Option_}
     use Wrap.{NoWrap, WrapOption}
-    use Context.{Instance, Static}
+    use Context.{Instance, Staticc}
 
     ///  Def(name, params, return type, effect, impl)
     pub enum Def(String, List[(String, Type_)], Type_, Effect, Impl) with Eq, Order
 
-    pub enum Impl(Import, Body) with Eq, Order 
+    pub enum Impl(Import, Body) with Eq, Order
 
     pub enum Import with Eq, Order {
 
@@ -71,7 +71,7 @@ mod Ast {
     }
 
     pub enum Context with Eq, Order {
-        case Static
+        case Staticc
         case Instance
     }
 
@@ -94,9 +94,9 @@ mod Ast {
 
     instance ToString[Def] {
         pub def toString(d: Def): String =
-            let Def(name, params, tpe, eff, impl) = d;
+            let Def(name, params, tpe, effct, impl) = d;
             let paramString = params |> List.map(match (n, t) -> "${n}: ${t}") |> String.intercalate(", ");
-            "pub def ${name}(${paramString}): ${tpe} \\ ${eff} = {\n" +
+            "pub def ${name}(${paramString}): ${tpe} \\ ${effct} = {\n" +
             "${impl}" |> String.indent(4) +
             "}\n"
     }
@@ -107,7 +107,7 @@ mod Ast {
             case IO_ => "IO"
         }
     }
-    
+
 
     instance ToString[Impl] {
         pub def toString(x: Impl): String =
@@ -130,16 +130,16 @@ mod Ast {
 
     instance ToString[Import] {
         pub def toString(x: Import): String = match x {
-            case Constructor(name, params, return, eff, alias_) =>
+            case Constructor(name, params, return, effct, alias_) =>
                 let paramString = params |> List.map(ToString.toString) |> String.intercalate(", ");
-                "import java_new ${name}(${paramString}): ${return} \\ ${eff} as ${alias_};\n"
-            case Method(context, name, params, return, eff, alias_) =>
+                "import java_new ${name}(${paramString}): ${return} \\ ${effct} as ${alias_};\n"
+            case Method(context, name, params, return, effct, alias_) =>
                 let paramString = params |> List.map(ToString.toString) |> String.intercalate(", ");
-                "import ${context}${name}(${paramString}): ${return} \\ ${eff} as ${alias_};\n"
-            case GetField(context, name, return, eff, func) =>
-                "import ${context}java_get_field ${name}: ${return} \\ ${eff} as ${func};\n"
-            case SetField(context, name, return, eff, func) =>
-                "import ${context}java_set_field ${name}: ${return} \\ ${eff} as ${func};\n"
+                "import ${context}${name}(${paramString}): ${return} \\ ${effct} as ${alias_};\n"
+            case GetField(context, name, return, effct, func) =>
+                "import ${context}java_get_field ${name}: ${return} \\ ${effct} as ${func};\n"
+            case SetField(context, name, return, effct, func) =>
+                "import ${context}java_set_field ${name}: ${return} \\ ${effct} as ${func};\n"
         }
     }
 
@@ -156,7 +156,7 @@ mod Ast {
             case NoCast(name) => "${name}"
         }
     }
-    
+
 
     instance ToString[Call] {
         pub def toString(x: Call): String =
@@ -164,16 +164,16 @@ mod Ast {
             let paramString = params |> List.map(ToString.toString) |> String.intercalate(", ");
             "${name}(${paramString})"
     }
-    
+
 
     instance ToString[Context] {
         pub def toString(x: Context): String = match x {
-            case Static => "static " // kind of hacky to put this in an instance
+            case Staticc => "static " // kind of hacky to put this in an instance
             case Instance => ""
         }
     }
-    
-    
+
+
 
     instance ToString[Type_] {
         pub def toString(x: Type_): String = match x {

--- a/src/Ast.flix
+++ b/src/Ast.flix
@@ -9,7 +9,7 @@ mod Ast {
     use Namespace.Namespace;
     use Type_.{Int8_, Int16_, Int32_, Int64_, Float32_, Float64_, Bool_, Char_, String_, BigInt_, Unit_, Ref_, Array_, Result_, Option_}
     use Wrap.{NoWrap, WrapOption}
-    use Context.{Instance, Staticc}
+    use Context.{Instance, Static_}
 
     ///  Def(name, params, return type, effect, impl)
     pub enum Def(String, List[(String, Type_)], Type_, Effect, Impl) with Eq, Order
@@ -71,7 +71,7 @@ mod Ast {
     }
 
     pub enum Context with Eq, Order {
-        case Staticc
+        case Static_
         case Instance
     }
 
@@ -94,9 +94,9 @@ mod Ast {
 
     instance ToString[Def] {
         pub def toString(d: Def): String =
-            let Def(name, params, tpe, effct, impl) = d;
+            let Def(name, params, tpe, effect, impl) = d;
             let paramString = params |> List.map(match (n, t) -> "${n}: ${t}") |> String.intercalate(", ");
-            "pub def ${name}(${paramString}): ${tpe} \\ ${effct} = {\n" +
+            "pub def ${name}(${paramString}): ${tpe} \\ ${effect} = {\n" +
             "${impl}" |> String.indent(4) +
             "}\n"
     }
@@ -130,16 +130,16 @@ mod Ast {
 
     instance ToString[Import] {
         pub def toString(x: Import): String = match x {
-            case Constructor(name, params, return, effct, alias_) =>
+            case Constructor(name, params, return, effect, alias_) =>
                 let paramString = params |> List.map(ToString.toString) |> String.intercalate(", ");
-                "import java_new ${name}(${paramString}): ${return} \\ ${effct} as ${alias_};\n"
-            case Method(context, name, params, return, effct, alias_) =>
+                "import java_new ${name}(${paramString}): ${return} \\ ${effect} as ${alias_};\n"
+            case Method(context, name, params, return, effect, alias_) =>
                 let paramString = params |> List.map(ToString.toString) |> String.intercalate(", ");
-                "import ${context}${name}(${paramString}): ${return} \\ ${effct} as ${alias_};\n"
-            case GetField(context, name, return, effct, func) =>
-                "import ${context}java_get_field ${name}: ${return} \\ ${effct} as ${func};\n"
-            case SetField(context, name, return, effct, func) =>
-                "import ${context}java_set_field ${name}: ${return} \\ ${effct} as ${func};\n"
+                "import ${context}${name}(${paramString}): ${return} \\ ${effect} as ${alias_};\n"
+            case GetField(context, name, return, effect, func) =>
+                "import ${context}java_get_field ${name}: ${return} \\ ${effect} as ${func};\n"
+            case SetField(context, name, return, effect, func) =>
+                "import ${context}java_set_field ${name}: ${return} \\ ${effect} as ${func};\n"
         }
     }
 
@@ -168,7 +168,7 @@ mod Ast {
 
     instance ToString[Context] {
         pub def toString(x: Context): String = match x {
-            case Staticc => "static " // kind of hacky to put this in an instance
+            case Static_ => "static " // kind of hacky to put this in an instance
             case Instance => ""
         }
     }

--- a/src/Transform.flix
+++ b/src/Transform.flix
@@ -89,10 +89,10 @@ mod Transform {
                 group
             } else {
                 group |> List.map(
-                    match Def(name, params, ret, effct, impl) ->
+                    match Def(name, params, ret, effect, impl) ->
                         let tpes = params |> List.map(snd) |> List.map(typeToIdentifierString);
                         let newName = name ++ String.intercalate("", tpes);
-                        Def(newName, params, ret, effct, impl)
+                        Def(newName, params, ret, effect, impl)
                 )
             }
         };
@@ -145,7 +145,7 @@ mod Transform {
         }
     }
 
-    def getMethodContext(m: Method): Context = if (isStaticMethod(m)) Context.Staticc else Context.Instance
+    def getMethodContext(m: Method): Context = if (isStaticMethod(m)) Context.Static_ else Context.Instance
 
     def isInheritedMethod(c: Class, m: Method): Bool = {
         let importClazzName = getClassName(c);
@@ -215,7 +215,7 @@ mod Transform {
             case Context.Instance =>
                 let paramNames = mkParamNames(getMethodParameterTypes(m) |> Array.length + 1);
                 List.map(Arg.NoCast, paramNames)
-            case Context.Staticc =>
+            case Context.Static_ =>
                 let paramNames = mkParamNames(getMethodParameterTypes(m) |> Array.length);
                 List.map(Arg.NoCast, paramNames)
         }
@@ -228,7 +228,7 @@ mod Transform {
                 let paramNames = mkParamNames(getMethodParameterTypes(m) |> Array.length + 1);
                 let paramTypes = visitType(c) :: importParamTypes;
                 List.zip(paramNames, paramTypes)
-            case Context.Staticc =>
+            case Context.Static_ =>
                 let paramNames = mkParamNames(getMethodParameterTypes(m) |> Array.length + 1);
                 let paramTypes = importParamTypes;
                 List.zip(paramNames, paramTypes)
@@ -246,9 +246,9 @@ mod Transform {
         let importReturnType = getReturnType(m) |> visitType;
         let context = getMethodContext(m);
         let importParamTypes = unchecked_cast({ getMethodParameterTypes(m) |> Array.toList |> List.map(visitType) } as _ \ {});
-        let effct = mkEffect(o, importReturnType);
+        let effect = mkEffect(o, importReturnType);
         let importName = importClazzName + "." + methodName;
-        let import_ = Import.Method(context, importName, importParamTypes, importReturnType, effct, alias_);
+        let import_ = Import.Method(context, importName, importParamTypes, importReturnType, effect, alias_);
 
         // build the call expression
         let doResult = shouldResultMethod(o, m);
@@ -262,7 +262,7 @@ mod Transform {
 
         let outerReturnType = mkOuterReturnType(doResult = doResult, doOption = doOption, importReturnType);
         let outerParams = mkOuterParams(c, m, importParamTypes);
-        Def(alias_, outerParams, outerReturnType, effct, impl)
+        Def(alias_, outerParams, outerReturnType, effect, impl)
     }
 
     pub def visitConstructor(o: Options, c: Class, cst: Constructor): Ast.Def = {
@@ -271,9 +271,9 @@ mod Transform {
         // build the import statement
         let importParamTypes = unchecked_cast({ getConstructorParameterTypes(cst) |> Array.toList |> List.map(visitType) } as _ \ {});
         let importReturnType = c |> visitType;
-        let effct = mkEffect(o, importReturnType);
+        let effect = mkEffect(o, importReturnType);
         let importName = getClassName(c);
-        let import_ = Import.Constructor(importName, importParamTypes, importReturnType, effct, alias_);
+        let import_ = Import.Constructor(importName, importParamTypes, importReturnType, effect, alias_);
 
         // build the call expression
         let doResult = shouldResultConstructor(o, cst);
@@ -287,7 +287,7 @@ mod Transform {
         let impl = Impl(import_, body);
         let outerReturnType = mkOuterReturnType(doResult = doResult, doOption = false, importReturnType);
         let outerParams = List.zip(paramNames, importParamTypes);
-        Def(alias_, outerParams, outerReturnType, effct, impl)
+        Def(alias_, outerParams, outerReturnType, effect, impl)
     }
 
 
@@ -302,8 +302,8 @@ mod Transform {
 
     /// Creates a getter for the given field.
     def mkGetter(o: Options, c: Class, f: Field): Ast.Def = {
-        let context = if (isStaticField(f)) Context.Staticc else Context.Instance;
-        let effct = match (o, isFinalField(f)) {
+        let context = if (isStaticField(f)) Context.Static_ else Context.Instance;
+        let effect = match (o, isFinalField(f)) {
             case (Options(opts), true) if opts.pureLevel >= PureLevel.PureFinal => Effect.Pure_
             case (Options(opts), _) if opts.pureLevel >= PureLevel.PureButUnit => Effect.Pure_
             case _ => Effect.IO_
@@ -313,13 +313,13 @@ mod Transform {
         let importClazzName = getClassName(importClazz);
         let fieldType = visitType(getType(f));
         let paramTypes = match context {
-            case Context.Staticc => Nil
+            case Context.Static_ => Nil
             case Context.Instance => visitType(c) :: Nil
         };
         let paramNames = List.range(0, List.length(paramTypes)) |> List.map(i -> "x${i}");
         let isInherited = importClazzName != getClassName(c);
         let args = match context {
-            case Context.Staticc => List.map(Arg.NoCast, paramNames)
+            case Context.Static_ => List.map(Arg.NoCast, paramNames)
             case Context.Instance if isInherited => match paramNames {
                 case hd :: tl => Arg.Cast(hd, visitType(importClazz)) :: List.map(Arg.NoCast, tl)
                 case Nil => bug!("unexpected empty parameter list")
@@ -328,7 +328,7 @@ mod Transform {
         };
         let params = List.zip(paramNames, paramTypes);
         let funcName = getterName(name);
-        let imp = Import.GetField(context, importClazzName + "." + name, fieldType, effct, funcName);
+        let imp = Import.GetField(context, importClazzName + "." + name, fieldType, effect, funcName);
         let call = Call(funcName, args);
         let doWrap = match (o, isPrimitive(getType(f))) {
             case (Options(opts), false) if opts.optionLevel >= OptionLevel.OptionRef => true
@@ -338,13 +338,13 @@ mod Transform {
         let wrap = if (doWrap) Wrap.WrapOption(call) else Wrap.NoWrap(call);
         let body = Body.NoTry(wrap);
         let impl = Impl(imp, body);
-        Def(funcName, params, outerReturnType, effct, impl)
+        Def(funcName, params, outerReturnType, effect, impl)
     }
 
     /// Creates a setter for the given field.
     def mkSetter(o: Options, c: Class, f: Field): Ast.Def = {
-        let context = if (isStaticField(f)) Context.Staticc else Context.Instance;
-        let effct = match o {
+        let context = if (isStaticField(f)) Context.Static_ else Context.Instance;
+        let effect = match o {
             case Options(opts) if opts.pureLevel >= PureLevel.PureAll => Effect.Pure_
             case _ => Effect.IO_
         };
@@ -353,13 +353,13 @@ mod Transform {
         let importClazzName = getClassName(importClazz);
         let fieldType = visitType(getType(f));
         let paramTypes = match context {
-            case Context.Staticc => fieldType :: Nil
+            case Context.Static_ => fieldType :: Nil
             case Context.Instance => visitType(c) :: fieldType :: Nil
         };
         let paramNames = List.range(0, List.length(paramTypes)) |> List.map(i -> "x${i}");
         let isInherited = importClazzName != getClassName(c);
         let args = match context {
-            case Context.Staticc => List.map(Arg.NoCast, paramNames)
+            case Context.Static_ => List.map(Arg.NoCast, paramNames)
             case Context.Instance if isInherited => match paramNames {
                 case hd :: tl => Arg.Cast(hd, visitType(importClazz)) :: List.map(Arg.NoCast, tl)
                 case Nil => bug!("unexpected empty parameter list")
@@ -368,12 +368,12 @@ mod Transform {
         };
         let params = List.zip(paramNames, paramTypes);
         let funcName = setterName(name);
-        let imp = Import.SetField(context, importClazzName + "." + name, Type_.Unit_, effct, funcName);
+        let imp = Import.SetField(context, importClazzName + "." + name, Type_.Unit_, effect, funcName);
         let call = Call(funcName, args);
         let wrap = Wrap.NoWrap(call);
         let body = Body.NoTry(wrap);
         let impl = Impl(imp, body);
-        Def(funcName, params, fieldType, effct, impl)
+        Def(funcName, params, fieldType, effect, impl)
     }
 
     /// Converts the Java class into a Flix type.

--- a/src/Transform.flix
+++ b/src/Transform.flix
@@ -59,7 +59,7 @@ mod Transform {
     /// Transforms the Java class into a Flix namespace.
     pub def visitClass(o: Options, c: Class): Result[Exception, Namespace] = {
         use Result.flatMap;
-        for (
+        forM (
             methods <- getMethodsFor(o, c);
             defs1 <- methods
                 |> List.filter(isBlackMagicMethod >> Utils.lnot)
@@ -89,10 +89,10 @@ mod Transform {
                 group
             } else {
                 group |> List.map(
-                    match Def(name, params, ret, eff, impl) ->
+                    match Def(name, params, ret, effct, impl) ->
                         let tpes = params |> List.map(snd) |> List.map(typeToIdentifierString);
                         let newName = name ++ String.intercalate("", tpes);
-                        Def(newName, params, ret, eff, impl)
+                        Def(newName, params, ret, effct, impl)
                 )
             }
         };
@@ -109,7 +109,7 @@ mod Transform {
         use Result.flatMap;
         let Options(opts) = o;
         let clazzName = getClassName(c);
-        for (
+        forM (
             methods <- getMethods(c)
         ) yield {
             unchecked_cast(match opts.superLevel {
@@ -125,7 +125,7 @@ mod Transform {
         use Result.flatMap;
         let Options(opts) = o;
         let clazzName = getClassName(c);
-        for (
+        forM (
             fields <- getFields(c)
         ) yield {
             unchecked_cast(match opts.superLevel {
@@ -138,14 +138,14 @@ mod Transform {
 
     def getConstructorsFor(_o: Options, c: Class): Result[Exception, List[Constructor]] = {
         use Result.flatMap;
-        for (
+        forM (
             csts <- getConstructors(c)
         ) yield {
             unchecked_cast({ csts |> Array.toList } as _ \ {})
         }
     }
 
-    def getMethodContext(m: Method): Context = if (isStaticMethod(m)) Context.Static else Context.Instance
+    def getMethodContext(m: Method): Context = if (isStaticMethod(m)) Context.Staticc else Context.Instance
 
     def isInheritedMethod(c: Class, m: Method): Bool = {
         let importClazzName = getClassName(c);
@@ -215,7 +215,7 @@ mod Transform {
             case Context.Instance =>
                 let paramNames = mkParamNames(getMethodParameterTypes(m) |> Array.length + 1);
                 List.map(Arg.NoCast, paramNames)
-            case Context.Static =>
+            case Context.Staticc =>
                 let paramNames = mkParamNames(getMethodParameterTypes(m) |> Array.length);
                 List.map(Arg.NoCast, paramNames)
         }
@@ -228,7 +228,7 @@ mod Transform {
                 let paramNames = mkParamNames(getMethodParameterTypes(m) |> Array.length + 1);
                 let paramTypes = visitType(c) :: importParamTypes;
                 List.zip(paramNames, paramTypes)
-            case Context.Static =>
+            case Context.Staticc =>
                 let paramNames = mkParamNames(getMethodParameterTypes(m) |> Array.length + 1);
                 let paramTypes = importParamTypes;
                 List.zip(paramNames, paramTypes)
@@ -246,9 +246,9 @@ mod Transform {
         let importReturnType = getReturnType(m) |> visitType;
         let context = getMethodContext(m);
         let importParamTypes = unchecked_cast({ getMethodParameterTypes(m) |> Array.toList |> List.map(visitType) } as _ \ {});
-        let eff = mkEffect(o, importReturnType);
+        let effct = mkEffect(o, importReturnType);
         let importName = importClazzName + "." + methodName;
-        let import_ = Import.Method(context, importName, importParamTypes, importReturnType, eff, alias_);
+        let import_ = Import.Method(context, importName, importParamTypes, importReturnType, effct, alias_);
 
         // build the call expression
         let doResult = shouldResultMethod(o, m);
@@ -262,7 +262,7 @@ mod Transform {
 
         let outerReturnType = mkOuterReturnType(doResult = doResult, doOption = doOption, importReturnType);
         let outerParams = mkOuterParams(c, m, importParamTypes);
-        Def(alias_, outerParams, outerReturnType, eff, impl)
+        Def(alias_, outerParams, outerReturnType, effct, impl)
     }
 
     pub def visitConstructor(o: Options, c: Class, cst: Constructor): Ast.Def = {
@@ -271,9 +271,9 @@ mod Transform {
         // build the import statement
         let importParamTypes = unchecked_cast({ getConstructorParameterTypes(cst) |> Array.toList |> List.map(visitType) } as _ \ {});
         let importReturnType = c |> visitType;
-        let eff = mkEffect(o, importReturnType);
+        let effct = mkEffect(o, importReturnType);
         let importName = getClassName(c);
-        let import_ = Import.Constructor(importName, importParamTypes, importReturnType, eff, alias_);
+        let import_ = Import.Constructor(importName, importParamTypes, importReturnType, effct, alias_);
 
         // build the call expression
         let doResult = shouldResultConstructor(o, cst);
@@ -287,7 +287,7 @@ mod Transform {
         let impl = Impl(import_, body);
         let outerReturnType = mkOuterReturnType(doResult = doResult, doOption = false, importReturnType);
         let outerParams = List.zip(paramNames, importParamTypes);
-        Def(alias_, outerParams, outerReturnType, eff, impl)
+        Def(alias_, outerParams, outerReturnType, effct, impl)
     }
 
 
@@ -302,8 +302,8 @@ mod Transform {
 
     /// Creates a getter for the given field.
     def mkGetter(o: Options, c: Class, f: Field): Ast.Def = {
-        let context = if (isStaticField(f)) Context.Static else Context.Instance;
-        let eff = match (o, isFinalField(f)) {
+        let context = if (isStaticField(f)) Context.Staticc else Context.Instance;
+        let effct = match (o, isFinalField(f)) {
             case (Options(opts), true) if opts.pureLevel >= PureLevel.PureFinal => Effect.Pure_
             case (Options(opts), _) if opts.pureLevel >= PureLevel.PureButUnit => Effect.Pure_
             case _ => Effect.IO_
@@ -313,13 +313,13 @@ mod Transform {
         let importClazzName = getClassName(importClazz);
         let fieldType = visitType(getType(f));
         let paramTypes = match context {
-            case Context.Static => Nil
+            case Context.Staticc => Nil
             case Context.Instance => visitType(c) :: Nil
         };
         let paramNames = List.range(0, List.length(paramTypes)) |> List.map(i -> "x${i}");
         let isInherited = importClazzName != getClassName(c);
         let args = match context {
-            case Context.Static => List.map(Arg.NoCast, paramNames)
+            case Context.Staticc => List.map(Arg.NoCast, paramNames)
             case Context.Instance if isInherited => match paramNames {
                 case hd :: tl => Arg.Cast(hd, visitType(importClazz)) :: List.map(Arg.NoCast, tl)
                 case Nil => bug!("unexpected empty parameter list")
@@ -328,7 +328,7 @@ mod Transform {
         };
         let params = List.zip(paramNames, paramTypes);
         let funcName = getterName(name);
-        let imp = Import.GetField(context, importClazzName + "." + name, fieldType, eff, funcName);
+        let imp = Import.GetField(context, importClazzName + "." + name, fieldType, effct, funcName);
         let call = Call(funcName, args);
         let doWrap = match (o, isPrimitive(getType(f))) {
             case (Options(opts), false) if opts.optionLevel >= OptionLevel.OptionRef => true
@@ -338,13 +338,13 @@ mod Transform {
         let wrap = if (doWrap) Wrap.WrapOption(call) else Wrap.NoWrap(call);
         let body = Body.NoTry(wrap);
         let impl = Impl(imp, body);
-        Def(funcName, params, outerReturnType, eff, impl)
+        Def(funcName, params, outerReturnType, effct, impl)
     }
 
     /// Creates a setter for the given field.
     def mkSetter(o: Options, c: Class, f: Field): Ast.Def = {
-        let context = if (isStaticField(f)) Context.Static else Context.Instance;
-        let eff = match o {
+        let context = if (isStaticField(f)) Context.Staticc else Context.Instance;
+        let effct = match o {
             case Options(opts) if opts.pureLevel >= PureLevel.PureAll => Effect.Pure_
             case _ => Effect.IO_
         };
@@ -353,13 +353,13 @@ mod Transform {
         let importClazzName = getClassName(importClazz);
         let fieldType = visitType(getType(f));
         let paramTypes = match context {
-            case Context.Static => fieldType :: Nil
+            case Context.Staticc => fieldType :: Nil
             case Context.Instance => visitType(c) :: fieldType :: Nil
         };
         let paramNames = List.range(0, List.length(paramTypes)) |> List.map(i -> "x${i}");
         let isInherited = importClazzName != getClassName(c);
         let args = match context {
-            case Context.Static => List.map(Arg.NoCast, paramNames)
+            case Context.Staticc => List.map(Arg.NoCast, paramNames)
             case Context.Instance if isInherited => match paramNames {
                 case hd :: tl => Arg.Cast(hd, visitType(importClazz)) :: List.map(Arg.NoCast, tl)
                 case Nil => bug!("unexpected empty parameter list")
@@ -368,12 +368,12 @@ mod Transform {
         };
         let params = List.zip(paramNames, paramTypes);
         let funcName = setterName(name);
-        let imp = Import.SetField(context, importClazzName + "." + name, Type_.Unit_, eff, funcName);
+        let imp = Import.SetField(context, importClazzName + "." + name, Type_.Unit_, effct, funcName);
         let call = Call(funcName, args);
         let wrap = Wrap.NoWrap(call);
         let body = Body.NoTry(wrap);
         let impl = Impl(imp, body);
-        Def(funcName, params, fieldType, eff, impl)
+        Def(funcName, params, fieldType, effct, impl)
     }
 
     /// Converts the Java class into a Flix type.

--- a/test/TestTransform.flix
+++ b/test/TestTransform.flix
@@ -77,7 +77,7 @@ mod TestTransform {
         let clazz = forNameString("java.lang.Class") |> unsafeGet;
         let string = forNameString("java.lang.String") |> unsafeGet;
         let method = getMethod(clazz, "forName", unchecked_cast(Array#{string} @ Static as _ \ {})) |> unsafeGet;
-        let imp = Import.Method(Context.Static, "java.lang.Class.forName", Type_.String_ :: Nil, Type_.Ref_("java.lang.Class"), Effect.IO_, "forName");
+        let imp = Import.Method(Context.Static_, "java.lang.Class.forName", Type_.String_ :: Nil, Type_.Ref_("java.lang.Class"), Effect.IO_, "forName");
         let call = Call("forName", mkArgs("x0" :: Nil));
         let wrap = Wrap.NoWrap(call);
         let body = Body.NoTry(wrap);
@@ -90,7 +90,7 @@ mod TestTransform {
         let clazz = forNameString("java.lang.Class") |> unsafeGet;
         let string = forNameString("java.lang.String") |> unsafeGet;
         let method = getMethod(clazz, "forName", unchecked_cast(Array#{string} @ Static as _ \ {})) |> unsafeGet;
-        let imp = Import.Method(Context.Static, "java.lang.Class.forName", Type_.String_ :: Nil, Type_.Ref_("java.lang.Class"), Effect.IO_, "forName");
+        let imp = Import.Method(Context.Static_, "java.lang.Class.forName", Type_.String_ :: Nil, Type_.Ref_("java.lang.Class"), Effect.IO_, "forName");
         let call = Call("forName", mkArgs("x0" :: Nil));
         let wrap = Wrap.NoWrap(call);
         let body = Body.TryCatch(wrap);
@@ -105,7 +105,7 @@ mod TestTransform {
         let clazz = forNameString("java.lang.Class") |> unsafeGet;
         let string = forNameString("java.lang.String") |> unsafeGet;
         let method = getMethod(clazz, "forName", unchecked_cast(Array#{string} @ Static as _ \ {})) |> unsafeGet;
-        let imp = Import.Method(Context.Static, "java.lang.Class.forName", Type_.String_ :: Nil, Type_.Ref_("java.lang.Class"), Effect.IO_, "forName");
+        let imp = Import.Method(Context.Static_, "java.lang.Class.forName", Type_.String_ :: Nil, Type_.Ref_("java.lang.Class"), Effect.IO_, "forName");
         let call = Call("forName", mkArgs("x0" :: Nil));
         let wrap = Wrap.WrapOption(call);
         let body = Body.TryCatch(wrap);
@@ -133,7 +133,7 @@ mod TestTransform {
     def testVisitField(): Bool = {
         let string = forNameString("java.lang.String") |> unsafeGet;
         let field = getField(string, "CASE_INSENSITIVE_ORDER") |> unsafeGet;
-        let imp = Import.GetField(Context.Static, "java.lang.String.CASE_INSENSITIVE_ORDER", Type_.Ref_("java.util.Comparator"), Effect.IO_, "getCASE_INSENSITIVE_ORDER");
+        let imp = Import.GetField(Context.Static_, "java.lang.String.CASE_INSENSITIVE_ORDER", Type_.Ref_("java.util.Comparator"), Effect.IO_, "getCASE_INSENSITIVE_ORDER");
         let call = Call("getCASE_INSENSITIVE_ORDER", Nil);
         let wrap = Wrap.NoWrap(call);
         let body = Body.NoTry(wrap);
@@ -145,7 +145,7 @@ mod TestTransform {
     def testVisitFieldPure(): Bool = {
         let string = forNameString("java.lang.String") |> unsafeGet;
         let field = getField(string, "CASE_INSENSITIVE_ORDER") |> unsafeGet;
-        let imp = Import.GetField(Context.Static, "java.lang.String.CASE_INSENSITIVE_ORDER", Type_.Ref_("java.util.Comparator"), Effect.Pure_, "getCASE_INSENSITIVE_ORDER");
+        let imp = Import.GetField(Context.Static_, "java.lang.String.CASE_INSENSITIVE_ORDER", Type_.Ref_("java.util.Comparator"), Effect.Pure_, "getCASE_INSENSITIVE_ORDER");
         let call = Call("getCASE_INSENSITIVE_ORDER", Nil);
         let wrap = Wrap.NoWrap(call);
         let body = Body.NoTry(wrap);
@@ -237,7 +237,7 @@ mod TestTransform {
     def testReturnNestedClass(): Bool = {
         let character = forNameString("java.lang.Character$UnicodeBlock") |> unsafeGet;
         let field = getField(character, "CUNEIFORM") |> unsafeGet;
-        let imp = Import.GetField(Context.Static, "java.lang.Character$UnicodeBlock.CUNEIFORM", Type_.Ref_("java.lang.Character$UnicodeBlock"), Effect.IO_, "getCUNEIFORM");
+        let imp = Import.GetField(Context.Static_, "java.lang.Character$UnicodeBlock.CUNEIFORM", Type_.Ref_("java.lang.Character$UnicodeBlock"), Effect.IO_, "getCUNEIFORM");
         let call = Call("getCUNEIFORM", Nil);
         let wrap = Wrap.NoWrap(call);
         let body = Body.NoTry(wrap);


### PR DESCRIPTION
With the new parser keywords `Static` and `eff` cannot be used as names anymore. 
Additionally `for` has been deprecated in favor of `forM`.